### PR TITLE
Add bathrooms for non-binary folk

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 2.0 Gener
 - Be mindful of how you identify the geographic region for the conference. DjangoCon Europe is notably not DjangoCon EU, because EU would mean we can’t have one in Switzerland. Communicate consistently on this.
 - Be very careful in how you describe your target group. If you use phrases like “advanced developers”, many people will not attend because they won’t feel advanced enough, or because they feel more like tech writers than developers. Also be mindful of terms like [technical and non-technical](http://anna-oz.tumblr.com/post/142527358160/people-are-people-contributions-are-contributions).
 - Make transgender people feel more at home with [posters stressing attendees shouldn’t judge who is using which bathroom](https://twitter.com/codingrixx/status/715558514631041025). There might be legal issues with doing this in some countries.
+- Make non-binary people feel more at home with explicitly gender-neutral bathrooms. This may also be helpful for parents and for other trans people. The Eliot Center, used by Open Source Bridge, has some toilets that are explicitly gender-neutral, as well as signs making it clear their binary gendered bathrooms are trans-inclusive.
 - Some ways to improve inclusivity may seem odd or useless to you as organisers. However, they can often make a big difference for other attendees in different positions and from different backgrounds, at little cost to you.
 
 ## Accessibility


### PR DESCRIPTION
Two of three incoming pull requests: "Make non-binary people feel more at home with explicitly gender-neutral bathrooms. This may also be helpful for parents and for other trans people. The Eliot Center, used by Open Source Bridge, has some toilets that are explicitly gender-neutral, as well as signs making it clear their binary gendered bathrooms are trans-inclusive."